### PR TITLE
Legg til ny route for Arena

### DIFF
--- a/app/components/Personalia.tsx
+++ b/app/components/Personalia.tsx
@@ -32,8 +32,12 @@ export function Personalia() {
   const ingenEndringerModalRef = useRef<HTMLDialogElement>(null);
   const opplysningId = searchParams.get("opplysningId");
   const behandlingId = searchParams.get("behandlingId");
+  const erArena = searchParams.get("erArena") || "false";
 
-  if (!params.inntektId || !behandlingId || !opplysningId) {
+  const erArenaBoolean = erArena === "true";
+  const manglerDpSakIder = !opplysningId || !behandlingId;
+
+  if (!params.inntektId || (!erArenaBoolean && manglerDpSakIder)) {
     throw new Error("inntektId, behandlingId eller opplysningId mangler i URL");
   }
 
@@ -42,9 +46,10 @@ export function Personalia() {
     schema: lagreEndringerSchema,
     defaultValues: {
       inntektId: params.inntektId,
-      behandlingId: behandlingId,
-      opplysningId: opplysningId,
+      behandlingId: behandlingId || undefined,
+      opplysningId: opplysningId || undefined,
       begrunnelse: "",
+      erArena: erArena,
     },
     method: "post",
     action: "/inntektId/$inntektId/action",

--- a/app/mocks/handlers.ts
+++ b/app/mocks/handlers.ts
@@ -16,4 +16,7 @@ export const handlers = [
   http.get(`${getEnv("DP_INNTEKT_API_URL")}/v1/inntekt/uklassifisert/uncached/:inntektId`, () => {
     return HttpResponse.json(mockUncachedUklassifisertInntekt);
   }),
+  http.get(`${getEnv("DP_INNTEKT_API_URL")}/v3/inntekt/inntektId/:aktorId/:kontekstType/:kontekstId/:beregningsDato`, () => {
+    return HttpResponse.text("1234");
+  }),
 ];

--- a/app/models/inntekt.server.ts
+++ b/app/models/inntekt.server.ts
@@ -6,9 +6,10 @@ export async function lagreInntekt(
   inntektId: string,
   behandlingId: string,
   opplysningId: string,
+  erArena: string,
   payload: string
 ) {
-  const url = `${getEnv("DP_INNTEKT_API_URL")}/v1/inntekt/uklassifisert/${inntektId}?behandlingId=${behandlingId}&opplysningId=${opplysningId}`;
+  const url = `${getEnv("DP_INNTEKT_API_URL")}/v1/inntekt/uklassifisert/${inntektId}?behandlingId=${behandlingId}&opplysningId=${opplysningId}&erArena=${erArena}`;
   const onBehalfOfToken = await getDPInntektOboToken(request);
 
   return await fetch(url, {
@@ -25,6 +26,21 @@ export async function lagreInntekt(
 
 export async function hentInntekt(request: Request, inntektId: string) {
   const url = `${getEnv("DP_INNTEKT_API_URL")}/v1/inntekt/uklassifisert/${inntektId}`;
+  const onBehalfOfToken = await getDPInntektOboToken(request);
+
+  return await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      Authorization: `Bearer ${onBehalfOfToken}`,
+      connection: "keep-alive",
+    },
+  });
+}
+
+export async function hentInntektId(request: Request, aktørId: string, kontekstType: string, kontekstId: string, beregningsDato: string) {
+  const url = `${getEnv("DP_INNTEKT_API_URL")}/v3/inntekt/inntektId/${aktørId}/${kontekstType}/${kontekstId}/${beregningsDato}`;
   const onBehalfOfToken = await getDPInntektOboToken(request);
 
   return await fetch(url, {

--- a/app/routes/inntektId.$inntektId.action.ts
+++ b/app/routes/inntektId.$inntektId.action.ts
@@ -8,6 +8,7 @@ export async function action({ request }: Route.ActionArgs) {
   const inntektId = entries["inntektId"] as string;
   const behandlingId = entries["behandlingId"] as string;
   const opplysningId = entries["opplysningId"] as string;
+  const erArena = entries["erArena"] as string || "false";
   const payload = entries["payload"] as string;
 
   const lagreInntektResponse = await lagreInntekt(
@@ -15,6 +16,7 @@ export async function action({ request }: Route.ActionArgs) {
     inntektId,
     behandlingId,
     opplysningId,
+    erArena,
     payload
   );
 
@@ -27,7 +29,13 @@ export async function action({ request }: Route.ActionArgs) {
 
   const nyInntektId = await lagreInntektResponse.text();
 
-  return redirect(
-    `/inntektId/${nyInntektId}?behandlingId=${behandlingId}&opplysningId=${opplysningId}`
-  );
+const queryParams = [
+  behandlingId && behandlingId !== "undefined" && `behandlingId=${behandlingId}`,
+  opplysningId && opplysningId !== "undefined" && `opplysningId=${opplysningId}`,
+  erArena && erArena !== "undefined" && `erArena=${erArena}`,
+].filter(Boolean).join("&");
+
+const redirectUrl = `/inntektId/${nyInntektId}${queryParams ? `?${queryParams}` : ""}`;
+
+return redirect(redirectUrl);
 }

--- a/app/routes/inntektId.$inntektId.tsx
+++ b/app/routes/inntektId.$inntektId.tsx
@@ -16,8 +16,20 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const url = new URL(request.url);
   const opplysningId = url.searchParams.get("opplysningId");
   const behandlingId = url.searchParams.get("behandlingId");
+  const erArena = url.searchParams.get("erArena");
 
-  if (!params.inntektId || !opplysningId || !behandlingId) {
+  if (!params.inntektId) {
+    Error("Mangler inntektId i params");
+  }
+
+  const erArenaBoolean = erArena === "true";
+  const manglerDpSakIder = !opplysningId || !behandlingId;
+
+  if (!erArenaBoolean && manglerDpSakIder) {
+    Error("Bruker kommer fra dp-sak, men mangler opplysningId eller behandlingId");
+  }
+
+  if (!params.inntektId || (!erArenaBoolean && manglerDpSakIder)) {
     return redirect("/sok");
   }
 

--- a/app/routes/inntekter.tsx
+++ b/app/routes/inntekter.tsx
@@ -1,0 +1,27 @@
+import {redirect} from "react-router";
+import type {Route} from "./+types/inntektId.$inntektId";
+import {hentInntektId} from "~/models/inntekt.server";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const url = new URL(request.url);
+
+  const aktørId = url.searchParams.get("aktorId");
+  const vedtakId = url.searchParams.get("vedtakId");
+  const beregningsdato = url.searchParams.get("beregningsdato");
+
+  // kontekstType kan være både "vedtak" og "saksbehandling" i backend,
+  //  men "vedtak" er det som brukes av Arena, så vi kan hardkode det her
+  const inntektIdResponse = await hentInntektId(request, aktørId!, "vedtak", vedtakId!, beregningsdato!);
+
+  if (!inntektIdResponse.ok) {
+    throw new Response("Feil ved henting av inntekter", {
+      status: inntektIdResponse.status,
+      statusText: inntektIdResponse.statusText,
+    });
+  }
+
+  const inntektId = await inntektIdResponse.text();
+
+  return redirect(`/inntektId/${inntektId}?erArena=true`);
+
+}

--- a/app/validation-schema/lagre-endringer-schema.ts
+++ b/app/validation-schema/lagre-endringer-schema.ts
@@ -11,10 +11,10 @@ export const lagreEndringerSchema = z.object({
   }),
   behandlingId: z.string({
     required_error: "BehandlingId er påkrevd",
-  }),
+  }).optional(),
   opplysningId: z.string({
     required_error: "OpplysningId er påkrevd",
-  }),
+  }).optional(),
   begrunnelse: z
     .string({
       required_error: "Begrunnelse er påkrevd",
@@ -22,4 +22,5 @@ export const lagreEndringerSchema = z.object({
     .refine((val) => /[a-zA-ZæøåÆØÅ]/.test(val ?? ""), {
       message: "Begrunnelse må inneholde minst én bokstav",
     }),
+  erArena: z.string().optional(),
 });


### PR DESCRIPTION
Vi tar inn de samme parameterne som i den gamle inntektsløsningen, sånn at Arena kun trenger å bytte ut ingressen. 
Deretter veksler vi inn til en inntektId i backend, og sender saksbehandler til redigeringssiden vi allerede har laget. 
Vi bruker et parameter for å holde styr på om man kommer fra Arena eller ikke, slik at vi kan håndtere det som feil hvis det mangler opplysningId og/eller behandlingId fra dp-sak. 
Lagringen vil bli likt som det vi allerede har laget, men med et "erArena"-parameter, slik at backend ikke trenger å oppdatere dp-behandling.