### PR TITLE
Legge til ny ad grupper

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -64,6 +64,7 @@ spec:
         groups:
           - id: "{{azure.grupper.saksbehandler}}"
           - id: "{{azure.grupper.beslutter}}"
+          - id: "{{azure.grupper.inntektsregistrering}}"
         extra:
           - NAVident
     sidecar:


### PR DESCRIPTION
Akkurat nå har vi:
- 0000-GA-Dagpenger-Saksbehandler
- 0000-GA-Dagpenger-Beslutter

Nye AD gruppe er 0000-GA-ARENA-DAGPENGER-INNTEKTSREGISTERING.

Ser at den nye har -ARENA som prefix. Litt usikker dette blir riktig på første forsøkt.