### PR TITLE
Disable lagre-knapp etter en lagring

### DIFF
--- a/app/components/Personalia.tsx
+++ b/app/components/Personalia.tsx
@@ -33,6 +33,7 @@ export function Personalia() {
   const opplysningId = searchParams.get("opplysningId");
   const behandlingId = searchParams.get("behandlingId");
   const erArena = searchParams.get("erArena") || "false";
+  const inntektLagret = searchParams.get("inntektLagret") === "true";
 
   const erArenaBoolean = erArena === "true";
   const manglerDpSakIder = !opplysningId || !behandlingId;
@@ -114,6 +115,7 @@ export function Personalia() {
             size="small"
             icon={<FloppydiskIcon title="a11y-title" fontSize="1.2rem" />}
             type="submit"
+            disabled={inntektLagret}
             onClick={() => {
               if (!inntektEndret) {
                 ingenEndringerModalRef?.current?.showModal();

--- a/app/routes/inntektId.$inntektId.action.ts
+++ b/app/routes/inntektId.$inntektId.action.ts
@@ -33,6 +33,7 @@ const queryParams = [
   behandlingId && behandlingId !== "undefined" && `behandlingId=${behandlingId}`,
   opplysningId && opplysningId !== "undefined" && `opplysningId=${opplysningId}`,
   erArena && erArena !== "undefined" && `erArena=${erArena}`,
+  "inntektLagret=true",
 ].filter(Boolean).join("&");
 
 const redirectUrl = `/inntektId/${nyInntektId}${queryParams ? `?${queryParams}` : ""}`;

--- a/app/routes/inntektId.$inntektId.tsx
+++ b/app/routes/inntektId.$inntektId.tsx
@@ -1,6 +1,6 @@
-import { Box, VStack } from "@navikt/ds-react";
+import { Alert, Box, VStack } from "@navikt/ds-react";
 import { useRef } from "react";
-import { data, redirect, useLoaderData } from "react-router";
+import { data, redirect, useLoaderData, useSearchParams } from "react-router";
 import { Header } from "~/components/Header";
 import { InntektPerioderOppsummering } from "~/components/InntektPeriodeSum";
 import InntektsKildeModal from "~/components/LeggTilInntektsKilde/InntektsKildeModal";
@@ -50,12 +50,21 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 export default function Inntekt() {
   const loaderData = useLoaderData<typeof loader>();
   const slettModalRef = useRef<HTMLDialogElement>(null);
+  const [searchParams] = useSearchParams();
+  const inntektLagret = searchParams.get("inntektLagret") === "true";
 
   return (
     <InntektProvider uklassifisertInntekt={loaderData} slettModalRef={slettModalRef}>
       <main>
         <VStack gap="6">
           <Header tittel="Dagpenger inntekt" />
+          {inntektLagret && (
+            <Alert variant="warning">
+              Inntekten er lagret, men opplysnings-ID-en kan ha endret seg. Vil du redigere
+              inntekten på nytt, må du gå tilbake til dp-sak, oppdatere siden og
+              klikke deg inn til inntektsredigeringen på nytt for å få korrekt opplysnings-ID.
+            </Alert>
+          )}
           <Personalia />
           <Box background="surface-default" padding="6" borderRadius="xlarge">
             <InntektPerioderOppsummering />


### PR DESCRIPTION
OpplysningId har endret seg i bakkant, uten at vi har tilgang på den. Hvis man forsøker å lagre på nytt, vil det feile. Derfor skrur vi nå av knappen og gir en infoboks etter en lagring, så man får hentet oppdatert ID fra dp-sak.

<img width="2549" height="1092" alt="image" src="https://github.com/user-attachments/assets/0c9da856-cddd-4588-8424-a30f700c688c" />
