### PR TITLE
Ikke skjul sensitive opplysninger som deafult

### DIFF
--- a/app/context/inntekt-context.tsx
+++ b/app/context/inntekt-context.tsx
@@ -38,7 +38,7 @@ function InntektProvider(props: PropsWithChildren<IInntektContextProps>) {
   const [inntektEndret, setInntektEndret] = useState(false);
   const [slettBekreftet, setSlettBekreftet] = useState(false);
   const [slettType, setSlettType] = useState<slettType>(undefined);
-  const [skjulSensitiveOpplysninger, setSkjulSensitiveOpplysninger] = useState(true);
+  const [skjulSensitiveOpplysninger, setSkjulSensitiveOpplysninger] = useState(false);
 
   // For å forhindre at brukeren kan navigere bort fra siden uten å lagre endringer
   useEffect(() => {


### PR DESCRIPTION
I de fleste tilfeller er det bare saksbehandler som går inn for å redigere, og da er det fint at alle opplysninger synes. Og så kan de heller trykke på knappen hvis det er behov for å vise siden til noen.